### PR TITLE
Build fast_float from source for OSS build

### DIFF
--- a/mcrouter/scripts/Makefile_ubuntu-24.04
+++ b/mcrouter/scripts/Makefile_ubuntu-24.04
@@ -16,7 +16,7 @@ mcrouter:
 deps: .folly-done .fizz-done .wangle-done .fmt-done .mvfst-done .fbthrift-done
 	touch $@
 
-.folly-done: .fmt-done
+.folly-done: .fmt-done .fast_float-done
 	${RECIPES_DIR}/folly.sh $(PKG_DIR) $(INSTALL_DIR) $(INSTALL_AUX_DIR)
 	touch $@
 
@@ -26,6 +26,10 @@ deps: .folly-done .fizz-done .wangle-done .fmt-done .mvfst-done .fbthrift-done
 
 .wangle-done: .folly-done .fizz-done
 	${RECIPES_DIR}/wangle.sh $(PKG_DIR) $(INSTALL_DIR) $(INSTALL_AUX_DIR)
+	touch $@
+
+.fast_float-done:
+	${RECIPES_DIR}/fast_float.sh $(PKG_DIR) $(INSTALL_DIR) $(INSTALL_AUX_DIR)
 	touch $@
 
 .fmt-done:

--- a/mcrouter/scripts/install_ubuntu_24.04.sh
+++ b/mcrouter/scripts/install_ubuntu_24.04.sh
@@ -26,7 +26,6 @@ sudo apt-get install -y \
     libbz2-dev \
     libdouble-conversion-dev \
     libevent-dev \
-    libfast-float-dev \
     libgflags-dev \
     libgoogle-glog-dev \
     libgmock-dev \

--- a/mcrouter/scripts/recipes/fast_float.sh
+++ b/mcrouter/scripts/recipes/fast_float.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+source common.sh
+
+if [[ ! -d "$PKG_DIR/fast_float" ]]; then
+  git clone --depth 1 -b v8.0.2 https://github.com/fastfloat/fast_float.git
+  cd "$PKG_DIR/fast_float" || die "cd failed"
+  mkdir "$PKG_DIR/fast_float/build"
+fi
+
+cd "$PKG_DIR/fast_float/build" || die "cd fast_float failed"
+
+CXXFLAGS="$CXXFLAGS -fPIC" \
+  cmake .. -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR"
+cmake --build . && cmake --install .


### PR DESCRIPTION
folly requires fast_float >= 8.0.0 since
https://github.com/facebook/folly/commit/7aa9b2c8f788561f99afbbddd40230ed501c3e44, whereas Ubuntu 24.04 packages version 3.9.0.

Add a build script for fast_float for use in the OSS build and use it instead of the distribution package.